### PR TITLE
Fix HID packet length match arms

### DIFF
--- a/src/keyboard/device/hid.rs
+++ b/src/keyboard/device/hid.rs
@@ -82,10 +82,7 @@ impl Keyboard {
             .ok_or_else(|| anyhow!("no device open"))?;
 
         match data.len() {
-            0..=20 => {
-                dev.write(data)?;
-            }
-            64 => {
+            0..=20 | 64 => {
                 dev.write(data)?;
             }
             n => return Err(anyhow!("invalid packet length: {n}")),


### PR DESCRIPTION
## Summary
- merge the identical HID packet length match arms so clippy no longer flags them【F:src/keyboard/device/hid.rs†L78-L88】

## Testing
- `cargo fmt --all -- --check`【a65c76†L1-L1】
- `cargo clippy --all-targets -- -D warnings -D clippy::pedantic -A clippy::too_many_lines`【0d6888†L1-L2】
- `cargo test`【6d2b94†L1-L17】

------
https://chatgpt.com/codex/tasks/task_e_68cd69c895fc832ea52dd0f92f15a945