### PR TITLE
style(clippy): merge identical HID packet length match arms

### DIFF
--- a/src/keyboard/device/hid.rs
+++ b/src/keyboard/device/hid.rs
@@ -82,10 +82,7 @@ impl Keyboard {
             .ok_or_else(|| anyhow!("no device open"))?;
 
         match data.len() {
-            0..=20 => {
-                dev.write(data)?;
-            }
-            64 => {
+            0..=20 | 64 => {
                 dev.write(data)?;
             }
             n => return Err(anyhow!("invalid packet length: {n}")),


### PR DESCRIPTION
Merged the identical HID packet length match arms in
Keyboard::send_packet to eliminate the clippy::match_same_arms warning.
